### PR TITLE
add Meteor.settings test

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -1,4 +1,4 @@
-var gaSettings = Meteor.settings.public &&
+var gaSettings = Meteor.settings && Meteor.settings.public &&
                  Meteor.settings.public.ga || {};
 
 if (gaSettings.id) {


### PR DESCRIPTION
On local deploy there is no Meteor.settings object. App breaks and throws error: "Uncaught TypeError: Cannot read property 'public' of undefined"
