### PR TITLE
fixed iron:router dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,9 +5,9 @@ Package.describe({
     git: "https://github.com/reywood/meteor-iron-router-ga.git"
 });
 
-Package.on_use(function(api) {
+Package.onUse(function(api) {
     api.versionsFrom("METEOR@0.9.0");
-    api.use("cmather:iron-router@0.8.2", "client");
+    api.use("iron:router", "client");
 
-    api.add_files([ "lib/ga.js", "lib/router.js" ], "client");
+    api.addFiles([ "lib/ga.js", "lib/router.js" ], "client");
 });


### PR DESCRIPTION
The cmather:iron-{x} packages were migrated to the new package system with the wrong name then later fixed, so dependencies need to be updated. Thanks!
