### PR TITLE
Server side universal-analytics & pageViewPath override per route

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Router.route("routeName", {
 });
 ```
 
+If you want to override pageview path for a certain route:
+
+```javascript
+Router.route("routeName/:id", {
+    // ...
+    trackPageView: true,
+    pageViewPath: 'routeName'
+    // ...
+});
+```
+
 ### A/B Testing with Content Experiments
 
 Each route in your app can be configured with an experiment ID and a list of templates to show for each variation. First, you must set up the experiment in your Google Analytics dashboard. Once that's done, add a `contentExperiment` configuration option to the route you want to experiment on (see snippet below for details). The number of templates specified in the `variationTemplates` array property *must* match the number of variations (including the original) configured for the experiment.

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,7 +8,6 @@ Router.route = function(name, options) {
 
 var attachAnalyticsOptions = function(options) {
     options = options || {};
-
     if (shouldTrackPageView.call(this, options)) {
         attachPageViewTracking.call(this, options);
     }
@@ -34,7 +33,12 @@ var attachPageViewTracking = function(options) {
     var originalOnRun = options.onRun;
 
     options.onRun = function() {
-        window.ga && window.ga("send", "pageview");
+        if(options.pageViewPath){
+            window.ga && window.ga("send", "pageview", options.pageViewPath);
+        }
+        else{
+            window.ga && window.ga("send", "pageview");
+        }
 
         return callEventHandlerOrNext.call(this, originalOnRun, arguments);
     };

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,26 @@
+var ua = Npm.require('universal-analytics');
+ga = function(user, options){
+    var gaSettings = Meteor.settings && Meteor.settings.public &&
+                 Meteor.settings.public.ga || {};
+    if (gaSettings.id) {
+        if(user){
+            return ua(gaSettings.id, user, options);        
+        }
+        else{
+            return ua(gaSettings.id);
+        }
+    } else {
+        console.log("iron-router-ga settings not found");
+        //returns fake tracker
+        return {
+            pageview:function(){return this;},
+            event:function(){return this;},
+            send:function(){return this;},
+            transaction:function(){return this;},
+            item:function(){return this;},
+            exception:function(){return this;},
+            timinig:function(){return this;},
+            debug:function(){return this;}
+        };
+    }
+};

--- a/package.js
+++ b/package.js
@@ -5,6 +5,8 @@ Package.describe({
     git: "https://github.com/reywood/meteor-iron-router-ga.git"
 });
 
+Npm.depends({"universal-analytics": "0.3.6"});
+
 Package.onUse(function(api) {
     api.versionsFrom("METEOR@1.0.1");
     api.use([ "templating", "iron:router@1.0.0" ], "client");
@@ -14,4 +16,7 @@ Package.onUse(function(api) {
         "lib/ga.js",
         "lib/router.js"
     ], "client");
+    
+    api.addFiles("lib/server.js", "server");
+    api.export('ga', ['server']);
 });


### PR DESCRIPTION
This adds server side universal-analytics as in https://www.npmjs.com/package/universal-analytics and pageViewPath override that can be set on a route basis. This way you can get /user/profile in your analytics instead of /user/profile/:id