### PR TITLE
Optionally block referral spam

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -40,7 +40,10 @@ function trackIfValidReferrer(err, response) {
 
   var isValid = typeof validate === 'undefined';
   if (isValid) {
+    window.localStorage.setItem('isReferralSpam', false);
     initTracking();
+  } else {
+    window.localStorage.setItem('isReferralSpam', true);
   }
 }
 

--- a/lib/ga.js
+++ b/lib/ga.js
@@ -1,15 +1,45 @@
 var gaSettings = Meteor.settings && Meteor.settings.public &&
                  Meteor.settings.public.ga || {};
 
-if (gaSettings.id) {
-    initPreloadAnalyticsHelper();
-    initTracker();
-    applySettings();
-    applyRequires();
-} else {
-    initFakeTracker();
+var blacklistURL = "https://s3.amazonaws.com/s3.convertify.io/spammers.txt";
+
+
+
+Meteor.startup(function(){
+  HTTP.call("GET", blacklistURL, trackIfValidReferrer);
+});
+
+function initTracking() {
+  if (gaSettings.id) {
+      initPreloadAnalyticsHelper();
+      initTracker();
+      applySettings();
+      applyRequires();
+  } else {
+      initFakeTracker();
+  }
 }
 
+function trackIfValidReferrer(err, response) {
+  if (err) {
+    // If for some reason the blacklist is unavailable, skip validation.
+    initTracking();
+  }
+  var spammers = response.content.split('\n');
+
+  var validate = _.find(spammers, function(referrer) {
+    if (!referrer.length) {
+      return false;
+    }
+    var re = new RegExp(referrer);
+    return re.test(document.referrer);
+  });
+
+  var isValid = typeof validate === 'undefined';
+  if (isValid) {
+    initTracking();
+  }
+}
 
 function initPreloadAnalyticsHelper() {
     window.ga = window.ga || function(){(ga.q=ga.q||[]).push(arguments);};

--- a/lib/ga.js
+++ b/lib/ga.js
@@ -4,10 +4,13 @@ var gaSettings = Meteor.settings && Meteor.settings.public &&
 var blacklistURL = "https://s3.amazonaws.com/s3.convertify.io/spammers.txt";
 
 
-
-Meteor.startup(function(){
-  HTTP.call("GET", blacklistURL, trackIfValidReferrer);
-});
+if (gaSettings.validateReferralSpam) {
+  Meteor.startup(function(){
+    HTTP.call("GET", blacklistURL, trackIfValidReferrer);
+  });
+} else {
+  initTracking();
+}
 
 function initTracking() {
   if (gaSettings.id) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,10 +1,14 @@
 var originalRoute = Router.route;
+var isValidReferrer = window.localStorage.getItem('isReferralSpam') !== null
+                        ? window.localStorage.getItem('isReferralSpam')
+                        : true;
 
-Router.route = function route(name, options) {
-    options = attachAnalyticsOptions.call(this, options);
-    return originalRoute.call(this, name, options);
-};
-
+if (validReferrer) {
+  Router.route = function route(name, options) {
+      options = attachAnalyticsOptions.call(this, options);
+      return originalRoute.call(this, name, options);
+  };
+}
 
 var attachAnalyticsOptions = function attachAnalyticsOptions(options) {
     options = options || {};


### PR DESCRIPTION
Not sure how big of an issue it is for everyone else, but I've been getting tons of referral spam lately on all my sites. This PR adds the option to block referral spam, by only activating analytics after validating the visitor's referrer against a community-maintained blacklist of known spammers. 

To enable it, set `Meteor.settings.public.ga.validateReferralSpam` to `"true"`.

Probably want to keep this PR open a while and get a survey of how many people this is an issue for before deciding whether to merge. 