### PR TITLE
Added the user ID when creating the GA

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -19,6 +19,10 @@ function initPreloadAnalyticsHelper() {
 function initTracker() {
     var createOptions = gaSettings.create || 'auto';
 
+    if (createOptions.userId === 'USER_ID' && Meteor.user()) {
+      createOptions.userId = Meteor.userId();
+    }
+
     window.ga('create', gaSettings.id, createOptions);
 }
 


### PR DESCRIPTION
This pull request contains some code to add the currently logged in user ID if the configuration contains:

```json
{
    "public": {
        "ga": {
            "id": "UA-XXXX-Y",
            "userId": "USER_ID"
        }
    }
}