### PR TITLE
Use userId instead of &uid

### DIFF
--- a/lib/ga.js
+++ b/lib/ga.js
@@ -23,7 +23,7 @@ function initTracker() {
     if (gaSettings.trackUserId) {
         Tracker.autorun(function() {
             if (Meteor.loggingIn()) { return; }
-            window.ga('set', '&uid', Meteor.userId());
+            window.ga('set', 'userId', Meteor.userId());
         });
     }
 }


### PR DESCRIPTION
According to the doc, it is not recommended to use ampersand syntax `&uid`, but instead use a human-readable `userId`

https://developers.google.com/analytics/devguides/collection/analyticsjs/accessing-trackers#ampersand_syntax
